### PR TITLE
Updated to use latest version of ServiceStack.Text

### DIFF
--- a/MailChimp/MailChimp.csproj
+++ b/MailChimp/MailChimp.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ServiceStack.Text">
-      <HintPath>..\packages\ServiceStack.Text.3.9.54\lib\net35\ServiceStack.Text.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Text.3.9.56\lib\net35\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -87,15 +87,15 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <Folder Include="Ecomm\" />
     <Folder Include="Folders\" />
     <Folder Include="Reports\" />
     <Folder Include="Templates\" />
     <Folder Include="Users\" />
     <Folder Include="VIP\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/MailChimp/Properties/AssemblyInfo.cs
+++ b/MailChimp/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.3")]
-[assembly: AssemblyFileVersion("1.0.0.3")]
+[assembly: AssemblyVersion("1.0.0.4")]
+[assembly: AssemblyFileVersion("1.0.0.4")]

--- a/MailChimp/packages.config
+++ b/MailChimp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ServiceStack.Text" version="3.9.54" targetFramework="net45" />
+  <package id="ServiceStack.Text" version="3.9.56" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I noticed that when I download the nuget package online, it tries to get the latest ServiceStack.Text reference. This breaks the code if you try and use the MailChimpManager class.

However, there might be a better way of doing this than my update!
