### PR TITLE
fixing mergeVar param of Subscribe method, fixes issue #5

### DIFF
--- a/MailChimp/MailChimpManager.cs
+++ b/MailChimp/MailChimpManager.cs
@@ -42,7 +42,7 @@ namespace MailChimp
         //  Default constructor
         public MailChimpManager()
         {
-            // remove "__type" information from ServiceStack.Text JSON Serializer
+            // remove "__type" member from ServiceStack.Text JSON Serializer serialized strings
             JsConfig.ExcludeTypeInfo = true;
         }
 


### PR DESCRIPTION
Changed the type of the mergeVar param of the Subscribe method to be an
object instead of MergeVar so that any serializable object can be passed
in.  This allows the user to derive from the MergeVars class and define
any custom merge variables they want to post to the Subscribe api call.
Also set JsConfig.ExcludeTypeInfo to true to supress the "__type" member
of the emitted JSON from appearing.
