### PR TITLE
Update BatchEmailParameter.cs

### DIFF
--- a/MailChimp/Lists/BatchEmailParameter.cs
+++ b/MailChimp/Lists/BatchEmailParameter.cs
@@ -35,7 +35,7 @@ namespace MailChimp.Lists
         /// data for the various list specific and special merge vars
         /// </summary>
         [DataMember(Name = "merge_vars")]
-        public MergeVar MergVars
+        public object MergVars
         {
             get;
             set;


### PR DESCRIPTION
An extension to issue #5.

Changed the type of the mergeVar param of the Subscribe method to be an
object instead of MergeVar so that any serializable object can be passed
in. This allows the user to derive from the MergeVars class and define
any custom merge variables they want to post to the Subscribe api call.
