### PR TITLE
Add using for ServiceStack

### DIFF
--- a/MailChimp/MailChimpManager.cs
+++ b/MailChimp/MailChimpManager.cs
@@ -8,6 +8,7 @@ using MailChimp.Helper;
 using MailChimp.Lists;
 using MailChimp.Templates;
 using MailChimp.Users;
+using ServiceStack;
 using ServiceStack.Text;
 using MailChimp.Reports;
 


### PR DESCRIPTION
Since ServiceStack.Text 4.0.8 moved the dynamic json extension methods to the ServiceStack namespace (out of ServiceStack.Text), have to add a using.
