### PR TITLE
TemplateInformationResult adjustments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,7 @@ _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
+.localhistory/
 
 # SQL Server files
 App_Data/*.mdf

--- a/MailChimp/Templates/TemplateInformationResult.cs
+++ b/MailChimp/Templates/TemplateInformationResult.cs
@@ -16,7 +16,7 @@ namespace MailChimp.Templates
         /// The default content broken down into the named editable sections for the template - dependant upon template, so not documented
         /// </summary>
         [DataMember(Name = "default_content")]
-        public object DefaultContent
+        public Dictionary<string,string> DefaultContent
         {
             get;
             set;
@@ -26,7 +26,7 @@ namespace MailChimp.Templates
         /// The valid editable section names - dependant upon template, so not documented
         /// </summary>
         [DataMember(Name = "sections")]
-        public object Sections
+        public Dictionary<string,string> Sections
         {
             get;
             set;


### PR DESCRIPTION
Changed TemplateInformationResult.DefaultContent and TemplateInformationResult.Sections to deserialize into a Dictionary<string,string> for easy lookup of content / sections.  The mailchimp docs do show this list of property/value pairs, although it isn't terribly clear in their docs.  This is how it is sent down to the client too in all the testing I've done against my templates.  ServiceStack appears to deserialize it correctly into the dictionary.

The .localhistory in .gitignore is from a Visual Studio plugin I use to track changes to files locally.

PS I'm new to git and its my first time contributing to github.  Let me know if I've messed something up!  :-)
