### PR TITLE
Added support for saved segments.

### DIFF
--- a/MailChimp.Tests/CampaignTests.cs
+++ b/MailChimp.Tests/CampaignTests.cs
@@ -86,6 +86,24 @@ namespace MailChimp.Tests
             //  Assert
             Assert.IsTrue(result.Total == 1);
         }
+	    [TestMethod]
+        public void CampaignSavedSegmentTest_Successful()
+        {
+            //  Arrange
+            MailChimpManager mc = new MailChimpManager(TestGlobal.Test_APIKey);
+            ListResult lists = mc.GetLists();
+            Assert.IsNotNull(lists);
+            Assert.IsTrue(lists.Data.Count > 0);
+            string listID = lists.Data[1].Id;
+            CampaignSegmentOptions options = new CampaignSegmentOptions();
+            options.SavedSegmentId = "yourSavedSegmentId";
+
+            //  Act
+            CampaignSegmentTestResult result = mc.CampaignSegmentTest(listID, options);
+            
+            //  Assert
+            Assert.IsTrue(result.Total > 0);
+        }
         [TestMethod]
         public void CampaignCreate_Successful()
         {

--- a/MailChimp.Tests/ListTests.cs
+++ b/MailChimp.Tests/ListTests.cs
@@ -350,5 +350,18 @@ namespace MailChimp.Tests
             StaticSegmentActionResult result = mc.ResetStaticSegment(lists.Data[1].Id, segments[0].StaticSegmentId);
             Assert.IsTrue(result.Complete);
         }
+	    [TestMethod]
+        public void GetSavedSegmentsForList_Successful()
+        {
+            // Arrange 
+            MailChimpManager mc = new MailChimpManager(TestGlobal.Test_APIKey);
+            ListResult lists = mc.GetLists();
+            
+            // Act
+            SegmentResult result = mc.GetSegmentsForList(lists.Data[1].Id, "saved");
+            
+            // Assert
+            Assert.IsTrue(result.SavedResult.Any());
+        }
     }
 }

--- a/MailChimp/Campaigns/CampaignSegmentOptions.cs
+++ b/MailChimp/Campaigns/CampaignSegmentOptions.cs
@@ -9,6 +9,15 @@ namespace MailChimp.Campaigns
     [DataContract]
     public class CampaignSegmentOptions
     {
+	    /// <summary>
+        /// a saved segment id from lists/segments() - this will take precendence, otherwise the match+conditions are required.
+        /// </summary>
+        [DataMember(Name = "saved_segment_id")]
+        public string SavedSegmentId
+        {
+            get;
+            set;
+        }
         /// <summary>
         /// Controls whether to use AND or OR when applying your options - expects "any" (for OR) or "all" (for AND)
         /// </summary>

--- a/MailChimp/Lists/SavedSegmentResult.cs
+++ b/MailChimp/Lists/SavedSegmentResult.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace MailChimp.Lists
+{
+    [DataContract]
+    public class SavedSegmentResult
+    {
+        /// <summary>
+        /// the id of the segment
+        /// </summary>
+        [DataMember(Name = "id")]
+        public int Id
+        {
+            get;
+            set;
+        }
+        /// <summary>
+        /// the name of the segment
+        /// </summary>
+        [DataMember(Name = "name")]
+        public string Name
+        {
+            get;
+            set;
+        }
+        /// <summary>
+        /// same match+conditions struct typically used
+        /// </summary>
+        [DataMember(Name = "segment_opts")]
+        public string SegmentOpts
+        {
+            get;
+            set;
+        }
+        /// <summary>
+        /// a textual description of the segment match/conditions
+        /// </summary>
+        [DataMember(Name = "segment_text")]
+        public string SegmentText
+        {
+            get;
+            set;
+        }
+        
+        /// <summary>
+        /// the date+time the segment was created
+        /// </summary>
+        [DataMember(Name = "created_date")]
+        public DateTime CreatedDate
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// the date+time the segment was last updated (add or del)
+        /// </summary>
+        [DataMember(Name = "last_update")]
+        public DateTime LastUpdate
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/MailChimp/Lists/SegmentResult.cs
+++ b/MailChimp/Lists/SegmentResult.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace MailChimp.Lists
+{
+    [DataContract]
+    public class SegmentResult
+    {
+        /// <summary>
+        /// array of structs with data for each segment
+        /// </summary>
+        [DataMember(Name = "static")]
+        public List<StaticSegmentResult> StaticResult
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// array of structs with data for each segment
+        /// </summary>
+        [DataMember(Name = "saved")]
+        public List<SavedSegmentResult> SavedResult
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/MailChimp/MailChimp.csproj
+++ b/MailChimp/MailChimp.csproj
@@ -128,6 +128,8 @@
     <Compile Include="Lists\StaticSegmentResult.cs" />
     <Compile Include="Lists\SubscriberLocation.cs" />
     <Compile Include="Lists\UnsubscribeResult.cs" />
+    <Compile Include="Lists\SavedSegmentResult.cs" />
+    <Compile Include="Lists\SegmentResult.cs" />
     <Compile Include="MailChimpManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Templates\TemplateAddResult.cs" />

--- a/MailChimp/MailChimpManager.cs
+++ b/MailChimp/MailChimpManager.cs
@@ -1171,6 +1171,27 @@ namespace MailChimp
             };
             return MakeAPICall<List<StaticSegmentResult>>(apiAction, args);
         }
+		
+	    /// <summary>
+        /// Retrieve all of Saved Segments for a list.
+        /// </summary>
+        /// <param name="listId">the list id to connect to. Get by calling lists/list()</param>
+        /// <param name="segmentType">optional - optional, if specified should be "static" or "saved" and will limit the returned entries to that type</param>
+        /// <returns></returns>
+        public SegmentResult GetSegmentsForList(string listId, string segmentType)
+        {
+            // our api action:
+            string apiAction = "lists/segments";
+
+            // create our arguements object:
+            object args = new
+            {
+                apikey = this.APIKey,
+                id = listId,
+                type = segmentType
+            };
+            return MakeAPICall<SegmentResult>(apiAction, args);
+        }
 
         #endregion
 


### PR DESCRIPTION
Allows users to get all saved segments and send campaigns to saved segments by its ids. 
This is useful for systems that must allow the users to change specific list filters directly through MailChimp' site, avoiding the need to create a filter UI or set hardcoded filters.
