### PR TITLE
Update ListError.cs

### DIFF
--- a/MailChimp/Lists/ListError.cs
+++ b/MailChimp/Lists/ListError.cs
@@ -12,7 +12,7 @@ namespace MailChimp.Lists
         /// whatever was passed in the batch record's email parameter
         /// </summary>
         [DataMember(Name = "email")]
-        public string Email
+        public EmailParameter Email
         {
             get;
             set;
@@ -31,7 +31,7 @@ namespace MailChimp.Lists
         /// <summary>
         /// the full error message
         /// </summary>
-        [DataMember(Name = "message")]
+        [DataMember(Name = "error")]
         public string ErrorMessage
         {
             get;


### PR DESCRIPTION
The API error response wasn't de-serialising email and error message correctly. From the API docs:
    "errors": [
        {
            "email": {
                "email": "example email",
                "euid": "example euid",
                "leid": "example leid"
            },
            "code": 42,
            "error": "example error",
            "row": {
                "...": "..."
            }
        }
