### PR TITLE
Fix to CampaignFilter class. Optional flag 'uses_segment' was non-nullabable bool

### DIFF
--- a/MailChimp/Campaigns/CampaignFilter.cs
+++ b/MailChimp/Campaigns/CampaignFilter.cs
@@ -136,10 +136,10 @@ namespace MailChimp.Campaigns
         }
 
         /// <summary>
-        /// whether to return just campaigns with or without segments
+        /// optional - whether to return just campaigns with or without segments
         /// </summary>
         [DataMember(Name = "uses_segment")]
-        public bool UsesSegment
+        public bool? UsesSegment
         {
             get;
             set;

--- a/MailChimp/Lists/ListError.cs
+++ b/MailChimp/Lists/ListError.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using MailChimp.Helper;
+using System.Runtime.Serialization;
 
 namespace MailChimp.Lists
 {


### PR DESCRIPTION
Optional flag "uses_segment" in the CampaignFilter class was changed to a non-nullable bool in the new iteration of the filter class. This meant you could only pull back a list of campaigns that used segments or campaigns that didn't but not both.
