### PR TITLE
Added support to inline-css method.

### DIFF
--- a/MailChimp.Tests/HelperTests.cs
+++ b/MailChimp.Tests/HelperTests.cs
@@ -114,5 +114,29 @@ namespace MailChimp.Tests
             Assert.IsTrue(matches.FullSearch.Total > 0);
             Assert.IsTrue(matches.FullSearch.Members.Any(member => member.Email == "customeremail@righthere.com"));
         }
+
+        [TestMethod]
+        public void InlineCss_Successful()
+        {
+            //  Arrange
+            MailChimpManager mc = new MailChimpManager(TestGlobal.Test_APIKey);
+
+            //  Act
+            string html = @"<html>
+	                            <style type=""text/css"">
+                                .style1 {
+                                    color: red;
+		                            font-weight: bold;
+                                }
+                            </style>
+	                            <body>
+		                            <p class=""style1"">Test</p>
+	                            </body>
+                            </html>";
+            InlineCss details = mc.InlineCss(html, false);
+
+            //  Assert
+            Assert.IsNotNull(details.Html);
+        }
     }
 }

--- a/MailChimp/Helper/InlineCss.cs
+++ b/MailChimp/Helper/InlineCss.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace MailChimp.Helper
+{
+    /// <summary>
+    /// Send your HTML content to have the CSS inlined and optionally remove the original styles.
+    /// More information: http://apidocs.mailchimp.com/api/2.0/helper/inline-css.php
+    /// </summary>
+    [DataContract]
+    public class InlineCss
+    {
+        /// <summary>
+        /// Your HTML content with all CSS inlined, just like if we sent it.
+        /// </summary>
+        [DataMember(Name = "html")]
+        public string Html
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/MailChimp/MailChimp.csproj
+++ b/MailChimp/MailChimp.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Campaigns\CampaignTypeRssOptions.cs" />
     <Compile Include="Campaigns\CampaignUpdateError.cs" />
     <Compile Include="Campaigns\CampaignUpdateResult.cs" />
+    <Compile Include="Helper\InlineCss.cs" />
     <Compile Include="Helper\Match.cs" />
     <Compile Include="Helper\Matches.cs" />
     <Compile Include="Lists\CompleteResult.cs" />

--- a/MailChimp/MailChimpManager.cs
+++ b/MailChimp/MailChimpManager.cs
@@ -1336,6 +1336,30 @@ namespace MailChimp
             return MakeAPICall<Matches>(apiAction, args);
         }
 
+        /// <summary>
+        /// Send your HTML content to have the CSS inlined and optionally remove the original styles.
+        /// More information: http://apidocs.mailchimp.com/api/2.0/helper/inline-css.php
+        /// </summary>
+        /// <param name="html">Your HTML content</param>
+        /// <param name="strip_css">optional - optional Whether you want the CSS <style> tags stripped from the returned document. Defaults to false.</param>
+        /// <returns></returns>
+        public InlineCss InlineCss(string html, bool strip_css = false)
+        {
+            //  Our api action:
+            string apiAction = "helper/inline-css";
+
+            //  Create our arguments object:
+            object args = new
+            {
+                apikey = this.APIKey,
+                html = html,
+                strip_css = strip_css
+            };
+
+            //  Make the call:
+            return MakeAPICall<InlineCss>(apiAction, args);
+        }
+
         #endregion
 
         #region API: Users


### PR DESCRIPTION
Some email clients break embedded CSS code. This method converts it to inline CSS for better compatibility.
