### PR TITLE
Added support for reports/click-detail

### DIFF
--- a/MailChimp/MailChimpManager.cs
+++ b/MailChimp/MailChimpManager.cs
@@ -1888,6 +1888,29 @@ namespace MailChimp
             return MakeAPICall<Clicks>(apiAction, args);
         }
 
+        /// <summary>
+        /// Retrieve click details of url.
+        /// </summary>
+        /// <param name="cId">the Campaign Id</param>
+        /// <param name="tId">the "tid" for the URL from reports/clicks</param>
+        /// <returns></returns>
+        public ClickDetail GetClickDetail(string cId, int tId)
+        {
+            //  Our api action:
+            string apiAction = "reports/click-detail";
+
+            //  Create our arguments object:
+            object args = new
+            {
+                apikey = this.APIKey,
+                cid = cId,
+                tid = tId
+            };
+
+            //  Make the call:
+            return MakeAPICall<ClickDetail>(apiAction, args);
+        }
+
         #endregion
 
         #region Generic API calling method

--- a/MailChimp/Reports/ClickDetail.cs
+++ b/MailChimp/Reports/ClickDetail.cs
@@ -1,0 +1,40 @@
+using System.Runtime.Serialization;
+using System.Collections.Generic;
+using MailChimp.Lists;
+
+namespace MailChimp.Reports
+{
+    [DataContract]
+    public class ClickDetail
+    {
+        /// <summary>
+        ///the total number of records matched to the URL and campaign
+        /// </summary>
+        /// 
+        [DataMember(Name = "total")]
+        public int Total { get; set; }
+
+        /// <summary>
+        /// structs for each click member matching
+        /// </summary>
+        [DataMember(Name = "data")]
+        public List<ClickDetailData> Data { get; set; }
+
+    }
+
+    [DataContract]
+    public class ClickDetailData
+    {
+        /// <summary>
+        /// the member record as returned by lists/member-info()
+        /// </summary>
+        [DataMember(Name = "member")]
+        public MemberInfo Member { get; set; }
+
+        /// <summary>
+        /// Total number of times the URL was clicked by this email address
+        /// </summary>
+        [DataMember(Name = "clicks")]
+        public int Clicks { get; set; }
+    }
+}


### PR DESCRIPTION
Added support for reports/click-detail that gets the email addresses that clicked on a URL based on the campaign id (cId) and url id (tId) gathered from reports/clicks as per question on #75.
