### PR TITLE
added support to Export API list command

### DIFF
--- a/MailChimp.Tests/MailChimp.Tests.csproj
+++ b/MailChimp.Tests/MailChimp.Tests.csproj
@@ -70,7 +70,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/MailChimp/MailChimp.sln
+++ b/MailChimp/MailChimp.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MailChimp", "MailChimp.csproj", "{4018D082-4F31-4013-B602-451666E07649}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4018D082-4F31-4013-B602-451666E07649}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4018D082-4F31-4013-B602-451666E07649}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4018D082-4F31-4013-B602-451666E07649}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4018D082-4F31-4013-B602-451666E07649}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/MailChimp/MailChimpManager.cs
+++ b/MailChimp/MailChimpManager.cs
@@ -10,9 +10,201 @@ using MailChimp.Reports;
 using MailChimp.Templates;
 using MailChimp.Users;
 using ServiceStack.Text;
+using System.IO;
+
 
 namespace MailChimp
 {
+    /// <summary>
+    /// .NET API Wrapper for the Mailchimp Export v1.0 API.
+    /// More information here: http://apidocs.mailchimp.com/export/1.0/mikko
+    /// </summary>
+    public class MailChimpExportManager
+    {
+        #region Fields and properties
+
+        /// <summary>
+        /// The HTTPS endpoint for the API.  
+        /// See http://apidocs.mailchimp.com/export/1.0/#api-endpoints for more information
+        /// </summary>
+        private string _httpsUrl = "https://{0}.api.mailchimp.com/export/1.0/{1}";
+
+        /// <summary>
+        /// The datacenter prefix.  This will be automatically determined
+        /// based on your API key
+        /// </summary>
+        private string _dataCenterPrefix = string.Empty;
+
+        #endregion
+
+        #region Constructors and API key
+
+        //  Default constructor
+        public MailChimpExportManager()
+        {
+            // remove "__type" member from ServiceStack.Text JSON Serializer serialized strings
+            JsConfig.ExcludeTypeInfo = true;
+        }
+
+        /// <summary>
+        /// Get the datacenter prefix based on the API key passed
+        /// </summary>
+        /// <param name="apiKey">v2.0 Mailchimp API key</param>
+        /// <returns></returns>
+        private string GetDatacenterPrefix(string apiKey)
+        {
+            //  The key should contain a '-'.  If it doesn't, throw an exception:
+            if (!apiKey.Contains('-'))
+            {
+                throw new ArgumentException("API key is not valid.  Must be a valid v2.0 Mailchimp API key.");
+            }
+
+            return apiKey.Split('-')[1];
+        }
+
+        /// <summary>
+        /// Create an instance of the wrappper with your API key
+        /// </summary>
+        /// <param name="apiKey">The MailChimp API key to use</param>
+        public MailChimpExportManager(string apiKey)
+            : this()
+        {
+            this.APIKey = apiKey;
+            this._dataCenterPrefix = GetDatacenterPrefix(apiKey);
+        }
+
+        /// <summary>
+        /// Gets / sets your API key for all operations.  
+        /// For help getting your API key, please see 
+        /// http://kb.mailchimp.com/article/where-can-i-find-my-api-key
+        /// </summary>
+        public string APIKey
+        {
+            get;
+            set;
+        }
+
+        #endregion
+
+        #region Generic API calling method
+
+        /// <summary>
+        /// Generic API call.  Expects to be able to serialize the results
+        /// to the specified type
+        /// </summary>
+        /// <typeparam name="T">The specified results type</typeparam>
+        /// <param name="apiAction">The API action.  Example: helper/account-details</param>
+        /// <param name="args">The object that will be serialized as the JSON parameters to the API call</param>
+        /// <returns></returns>
+        private List<Dictionary<string, string>> MakeAPICallForGetAllMembersForList(string apiAction, object args)
+        {
+            //  First, make sure the datacenter prefix is set properly.  
+            //  If it's not, throw an exception:
+            if (string.IsNullOrEmpty(_dataCenterPrefix))
+                throw new ApplicationException("API key not valid (datacenter not specified)");
+
+            //  Next, construct the full url based on the passed apiAction:
+            string fullUrl = string.Format(_httpsUrl, _dataCenterPrefix, apiAction);
+            Dictionary<String, String> parameters = args.ToStringDictionary();
+
+            string apikey = "?apikey=" + parameters["apikey"];
+            string id = "&id=" + parameters["id"];
+            string status = "&status=" + parameters["status"];
+            string since = "&since=" + parameters["since"];
+
+            fullUrl += apikey + id + status + since;
+
+            //  Initialize the results to return:
+            List<Dictionary<string, string>> returnList = new List<Dictionary<string, string>>();
+
+            try
+            {
+                //  Call the API with the passed arguments:
+
+                string testi = WebRequestExtensions.GetStringFromUrl(fullUrl);
+
+                var fromJson = JsonSerializer.DeserializeFromString<object>(testi);
+                string[] listofmembers;
+                List<string> iListofMembers = new List<string>();
+                string memberString = fromJson.ToString();
+
+                char[] delimiterChars = { '[', ']', };
+                listofmembers = memberString.Split(delimiterChars);
+
+                foreach (string row in listofmembers)
+                {
+                    if (row.Length > 4)
+                    iListofMembers.Add(row);
+                }
+                string[] keys = iListofMembers[0].Split(',');
+                
+                iListofMembers.RemoveAt(0);
+
+                for (int i = 0; i < iListofMembers.Count; i++)
+                {
+                    string[] values = iListofMembers[i].Split(',');
+                    Dictionary<string, string> contact = new Dictionary<string,string>();
+                    for (int j = 0; j < keys.Count(); j++)
+                    {
+                        contact.Add(keys[j], values[j]);
+                    }
+                    returnList.Add(contact);
+                }
+            }
+            catch (Exception ex)
+            {
+                string errorBody = ex.GetResponseBody();
+
+                //  Serialize the error information:
+                ApiError apiError = errorBody.FromJson<ApiError>();
+
+                //  Throw a new exception based on this information:
+                throw new MailChimpAPIException(apiError.Error, ex, apiError);
+            }
+
+            //  Return the results
+            return returnList;
+        }
+
+        #endregion
+
+        #region API Methods
+
+        /// <summary>
+        /// Exports/dumps members of a list and all of their associated details. 
+        /// This is a very similar to exporting via the web interface.
+        /// </summary>
+        /// <param name="listId">the list id to connect to (can be gathered using GetLists())</param>
+        /// <param name="status">optional - the status to get members for - one of(subscribed, unsubscribed, cleaned)</param>
+        /// <param name="segment">refine the members list by segments (maximum of 5 conditions)</param>
+        /// <param name="since">only return member whose data has changed since a GMT timestamp – in YYYY-MM-DD HH:mm:ss format</param>
+        /// <param name="hashed"> if, instead of full list data, you'd prefer a hashed list of email addresses, set this to the hashing algorithm you expect. Currently only "sha256" is supported. NOT IN USE NOW</param>        
+        /// <returns></returns>
+        public List<Dictionary<string, string>> GetAllMembersForList(string listId, string status = "subscribed", CampaignSegmentOptions segment = null , string since = "", string hashed = "")
+            //int start = 0, int limit = 25, string sort_field = "", string sort_dir = "ASC", CampaignSegmentOptions segment = null)
+        {
+            //  Our api action:
+            string apiAction = "list";
+
+            //  Create our arguments object:
+            object args = new
+            {
+                apikey = this.APIKey,
+                id = listId,
+                status = status,
+                //segment = segment,
+                since = since,
+                //hashed = hashed
+            };
+
+            //  Make the call:
+            return MakeAPICallForGetAllMembersForList(apiAction, args);
+        }
+
+        #endregion
+
+    }
+
     /// <summary>
     /// .NET API Wrapper for the Mailchimp v2.0 API.
     /// More information here: http://apidocs.mailchimp.com/api/2.0/


### PR DESCRIPTION
Hi!

Since MailChimp.NET doesn't support Export API 1.0 and its list command, which has that very neat "Since" parameter to fetch only updated list members, I did my own fork.

This version is kind of fast done and it only does what I needed it to do. It supports only Export API's list command, and returns List of Dictionary (of string, string) instead of returning custom object, like MembersResult for example. That's because I didn't succeed to convert JSON string into a object same way like MailChimpManager does. Instead, this code parses incoming string manually to List of Dictionary. So, problem solved.

Changes involve MailChimpExportManager class including GetAllMembersForList(...) method and customized MakeAPICall method.

Feel free to use or modify :)
