### PR TITLE
Implemented /reports/not-opened

### DIFF
--- a/MailChimp/MailChimp.csproj
+++ b/MailChimp/MailChimp.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Reports\ClickDetail.cs" />
     <Compile Include="Reports\CommonOptions.cs" />
     <Compile Include="Reports\BounceMessages.cs" />
+    <Compile Include="Reports\NotOpened.cs" />
     <Compile Include="Reports\Opened.cs" />
     <Compile Include="Reports\SentTo.cs" />
     <Compile Include="Reports\Clicks.cs" />

--- a/MailChimp/MailChimpManager.cs
+++ b/MailChimp/MailChimpManager.cs
@@ -1938,6 +1938,29 @@ namespace MailChimp
         }
 
         /// <summary>
+        /// Retrieve the list of email addresses that did not open a given campaign
+        /// </summary>
+        /// <param name="cId">the Campaign Id</param>
+        /// <param name="opts">optional - various options for controlling returned data</param>
+        /// <returns></returns>
+        public NotOpened GetReportNotOpened(string cId, CommonOptions opts = null)
+        {
+            //  Our api action:
+            string apiAction = "reports/not-opened";
+
+            //  Create our arguments object:
+            object args = new
+            {
+                apikey = this.APIKey,
+                cid = cId,
+                opts = opts
+            };
+
+            //  Make the call:
+            return MakeAPICall<NotOpened>(apiAction, args);
+        }
+
+        /// <summary>
         /// Get all unsubscribed email addresses for a given campaign
         /// </summary>
         /// <param name="cId">the Campaign Id</param>

--- a/MailChimp/Reports/ClickDetail.cs
+++ b/MailChimp/Reports/ClickDetail.cs
@@ -27,6 +27,7 @@ namespace MailChimp.Reports
 
     }
 
+    [DataContract]
     public class MemberClicks
     {
         /// <summary>

--- a/MailChimp/Reports/NotOpened.cs
+++ b/MailChimp/Reports/NotOpened.cs
@@ -1,0 +1,28 @@
+﻿using MailChimp.Lists;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace MailChimp.Reports
+{
+    /// <summary>
+    /// containing the total records matched and the specific records for this page
+    /// </summary>
+    [DataContract]
+    public class NotOpened
+    {
+        /// <summary>
+        /// the total number of members who didn't open the campaign
+        /// </summary>
+        [DataMember(Name = "total")]
+        public int Total { get; set; }
+
+        /// <summary>
+        /// structs for each campaign member matching as returned by lists/member-info()
+        /// </summary>
+        [DataMember(Name = "data")]
+        public List<MemberInfo> Data { get; set; }
+    }
+}


### PR DESCRIPTION
Hey Dan,

I've implemented /reports/not-opened.

I originally forgot to include the [DataContract] tag on the MemberClicks class when I implemented /api/click-detail which was causing some inconsistent naming of properties when serializing the class back to JSON. That's been added on there now as well.

-Andrew
