### PR TITLE
Add missing optional parameter 'counts'

### DIFF
--- a/MailChimp.Tests/ListTests.cs
+++ b/MailChimp.Tests/ListTests.cs
@@ -99,6 +99,22 @@ namespace MailChimp.Tests
         }
 
         [TestMethod]
+        public void GetListInterestGroupingsWithCountRequested_Successful()
+        {
+            //  Arrange
+            MailChimpManager mc = new MailChimpManager("efb48a02f2f56120e2f3f6e2fef71803-us6");
+            ListResult lists = mc.GetLists(new ListFilter() { ListName = "TestAPIGetInterestGroup" });
+            Assert.IsNotNull(lists);
+            Assert.IsTrue(lists.Data.Any());
+            //  Act
+            List<InterestGrouping> results = mc.GetListInterestGroupings(lists.Data.FirstOrDefault().Id, true);
+
+            //  Assert
+            Assert.IsNotNull(results);
+            Assert.IsTrue(results.Any());
+        }
+
+        [TestMethod]
         public void Subscribe_Successful()
         {
             //  Arrange

--- a/MailChimp/Lists/InterestGrouping.cs
+++ b/MailChimp/Lists/InterestGrouping.cs
@@ -47,6 +47,9 @@ namespace MailChimp.Lists
             [DataMember(Name = "bit")]
             public int Bit { get; set; }
 
+            [DataMember(Name = "subscribers")]
+            public int Subscribers { get; set; }
+
             [DataMember(Name = "name")]
             public string Name { get; set; }
 

--- a/MailChimp/MailChimpManager.cs
+++ b/MailChimp/MailChimpManager.cs
@@ -900,9 +900,10 @@ namespace MailChimp
         /// <summary>
         /// Retrieve the interest groups for a list.
         /// </summary>
-        /// <param name="listId"></param>
+        /// <param name="listId">The list id to connect to (can be gathered using GetLists())</param>
+        /// <param name="counts">Optional: whether or not to return subscriber counts for each group. Defaults to false since that slows this call down a ton for large lists.</param>
         /// <returns></returns>
-        public List<InterestGrouping> GetListInterestGroupings(string listId)
+        public List<InterestGrouping> GetListInterestGroupings(string listId, bool counts = false)
         {
             //  Our api action:
             string apiAction = "lists/interest-groupings";
@@ -911,7 +912,8 @@ namespace MailChimp
             object args = new
             {
                 apikey = this.APIKey,
-                id = listId
+                id = listId,
+                counts = counts
             };
 
             //  Make the call:


### PR DESCRIPTION
Adds the optional parameter 'counts' to GetListInterestGroupings. This parameter returns the total number of subscribers for each group.
