### PR TITLE
Add additional constructor for use after OAuth connection

### DIFF
--- a/MailChimp.Tests/APIKeyTests.cs
+++ b/MailChimp.Tests/APIKeyTests.cs
@@ -22,5 +22,23 @@ namespace MailChimp.Tests
             Assert.AreEqual<string>("us2", dataCenterPrefix);
 
         }
+
+        [TestMethod]
+        public void ValidOAuthKeys_ReturnsCorrectDataCenter()
+        {
+            //  Arrange
+            string accessToken = "testaccesstoken";
+            string dataCenter = "us2";
+
+            //  Act
+            MailChimpManager mc = new MailChimpManager(accessToken, dataCenter);
+
+            PrivateObject po = new PrivateObject(mc);
+            string dataCenterPrefix = po.GetField("_dataCenterPrefix").ToString();
+
+            //  Assert
+            Assert.AreEqual<string>("us2", dataCenterPrefix);
+
+        }
     }
 }

--- a/MailChimp/MailChimpManager.cs
+++ b/MailChimp/MailChimpManager.cs
@@ -75,6 +75,19 @@ namespace MailChimp
         }
 
         /// <summary>
+        /// Create an instance of the wrapper with an Access Token and a datacenter prefix
+        /// -- Primarily used when OAuth has been used to connect to MailChimp
+        /// </summary>
+        /// <param name="accessToken">The access token obtained through an OAuth call</param>
+        /// <param name="dataCenterPrefix">The data center prefix obtained following an OAuth call</param>
+        public MailChimpManager(string accessToken, string dataCenterPrefix)
+            :this()
+        {
+            this.APIKey = accessToken;
+            this._dataCenterPrefix = dataCenterPrefix;
+        }
+
+        /// <summary>
         /// Gets / sets your API key for all operations.  
         /// For help getting your API key, please see 
         /// http://kb.mailchimp.com/article/where-can-i-find-my-api-key


### PR DESCRIPTION
When using the web server flow of the OAuth2 protocol to connect to MailChimp, you don't get an API key of the same form as supplied from the management portal.  In particular, you get two parts: an access token (in OAuth2 terms) which functions as an api key [but crucially doesn't have a data center prefix on the end], and a separate data center prefix.

As a result, we need a further constructor for MailChimpManager which takes these two parts separately.

It would, I suppose, be possible to have combined them in the caller - only to have the library take them apart again, but that seemed wasteful and confusing.
