### PR TITLE
Stats didn't match API Documentation in ListInfo

### DIFF
--- a/MailChimp/Lists/ListInfo.cs
+++ b/MailChimp/Lists/ListInfo.cs
@@ -165,52 +165,52 @@ namespace MailChimp.Lists
         public class ListStats
         {
             [DataMember(Name = "member_count")]
-            public int MemberCount { get; set; }
+            public double MemberCount { get; set; }
 
             [DataMember(Name = "unsubscribe_count")]
-            public int UnsubscribeCount { get; set; }
+            public double UnsubscribeCount { get; set; }
         
             [DataMember(Name = "cleaned_count")]
-            public int CleanedCount { get; set; }
+            public double CleanedCount { get; set; }
 
             [DataMember(Name = "member_count_since_send")]
-            public int MemberCountSinceSend  { get; set; }
+            public double MemberCountSinceSend { get; set; }
 
             [DataMember(Name = "unsubscribe_count_since_send")]
-            public int UnsubscribeCountSinceSend { get; set; }
+            public double UnsubscribeCountSinceSend { get; set; }
 
             [DataMember(Name = "cleaned_count_since_send")]
-            public int CleanedCountSinceSend { get; set; }
+            public double CleanedCountSinceSend { get; set; }
 
             [DataMember(Name = "campaign_count")]
-            public int CampaignCount { get; set; }
+            public double CampaignCount { get; set; }
             
             [DataMember(Name = "grouping_count")]
-            public int GroupingCount { get; set; }
+            public double GroupingCount { get; set; }
 
             [DataMember(Name = "group_count")]
-            public int GroupCount { get; set; }
+            public double GroupCount { get; set; }
 
             [DataMember(Name = "merge_var_count")]
-            public int MergeVarCount { get; set; }
+            public double MergeVarCount { get; set; }
 
             [DataMember(Name = "avg_sub_rate")]
-            public int AvgSubRate { get; set; }
+            public double AvgSubRate { get; set; }
 
             [DataMember(Name = "avg_unsub_rate")]
-            public int AvgUnsubRate { get; set; }
+            public double AvgUnsubRate { get; set; }
 
             [DataMember(Name = "target_sub_rate")]
-            public int TargetSubRate { get; set; }
+            public double TargetSubRate { get; set; }
 
             [DataMember(Name = "open_rate")]
-            public int OpenRate { get; set; }
+            public double OpenRate { get; set; }
 
             [DataMember(Name = "click_rate")]
-            public int ClickRate { get; set; }
+            public double ClickRate { get; set; }
 
             [DataMember(Name = "date_last_campaign")]
-            public int DateLastCampaign { get; set; }
+            public System.DateTime DateLastCampaign { get; set; }
         }
 
     }


### PR DESCRIPTION
In the api All of the properties are Doubles not ints.  This change makes int consistent, additionally changed the undocumented DateLastCampaign to System.DateTime
