### PR TITLE
Group.Id is not required, make it nullable

### DIFF
--- a/MailChimp/Lists/Grouping.cs
+++ b/MailChimp/Lists/Grouping.cs
@@ -14,7 +14,7 @@ namespace MailChimp.Lists
         /// this id takes precedence and can't change (unlike the name)
         /// </summary>
         [DataMember(Name = "id")]
-        public int Id
+        public int? Id
         {
             get;
             set;


### PR DESCRIPTION
Prevent assigning a 0 when converted to json and no value is assigned.
