### PR TITLE
New improved parser to MailChimpExportManager

### DIFF
--- a/MailChimp/MailChimpExportManager.cs
+++ b/MailChimp/MailChimpExportManager.cs
@@ -95,34 +95,6 @@ namespace MailChimp
 			return utcSyncString;
 		}
 
-		static string ReturnFullUrlWithParameters(String url, object args)
-		{
-			string returnString = url;
-			Dictionary<String, String> parameters = args.ToStringDictionary();
-			List<string> keys = new List<string>();
-			List<string> values = new List<string>();
-			
-			foreach(var pair in parameters)
-			{
-				keys.Add(pair.Key);
-				values.Add(pair.Value);
-			}
-
-			for (int i = 0; i < parameters.Count; i++)
-			{
-				if (i == 0)
-				{
-					returnString += "?" + keys[i] + "=" + values[i];
-				}
-				else
-				{
-					returnString += "&" + keys[i] + "=" + values[i];
-				}
-			}
-
-			return returnString;
-		}
-
 		static List<Dictionary<string, string>> ParseExportApiResults(string stringFromServer)
 		{
 			List<Dictionary<string, string>> returnList = new List<Dictionary<string, string>>();


### PR DESCRIPTION
Earlier parser was using only comma as delimiter to separate all stuff. That means problems when trying to parse json with commas inside strings. This one fixes the problem. Also quotation marks inside strings should be fine too. Now it also works with different types of variables coming from json for example null values, integers and booleans. This parser turns them all to string into Dictionary(of string). 

Tested & it should work fine now. Let me know if problems occur
